### PR TITLE
MC-12110: Updated pom.xml to use plugin-starter:23.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,42 +2,17 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.cloudops</groupId>
+  <parent>
+    <groupId>com.cloudops</groupId>
+    <artifactId>cloudmc-plugin-starter</artifactId>
+    <version>23.0.0-SNAPSHOT</version>
+  </parent>
   <artifactId>cloudmc-todoist-plugin</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <properties>
-    <spring.version>4.3.2.RELEASE</spring.version>
     <cloudmc.buildName>cloudmc-todoist-plugin</cloudmc.buildName>
   </properties>
   <dependencies>
-    <dependency>
-      <groupId>com.cloudops</groupId>
-      <artifactId>cloudmc-service-plugin-sdk</artifactId>
-      <version>17.0.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-      <version>${spring.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.5</version>
-    </dependency>
-    <dependency>
-      <groupId>cglib</groupId>
-      <artifactId>cglib</artifactId>
-      <version>3.2.4</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.spockframework</groupId>
-      <artifactId>spock-core</artifactId>
-      <version>1.1-groovy-2.4</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>


### PR DESCRIPTION
### Fixes [MC-12110](https://cloud-ops.atlassian.net/browse/MC-12110)

#### Code walkthrough : NA
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
Plugin-starter should be used for common dependencies across all plugins including SDK.

#### Solution
Updated pom file to use plugin-starter as parent pom and removed dependencies which are already in plugin-starter.

#### Test cases
- NA

#### UI changes
No changes

<!-- Uncomment if PRs from other repos related to the same story 
#### Related PRs
- PR #
-->
